### PR TITLE
Provide collectable and enumerable interface to process communication

### DIFF
--- a/lib/ex_cmd.ex
+++ b/lib/ex_cmd.ex
@@ -1,38 +1,9 @@
 defmodule ExCmd do
-  alias ExCmd.ProcServer
   require Logger
 
   @default_opts %{log: false}
-  def stream(stream, cmd, args \\ [], opts \\ %{}) do
+  def stream!(cmd, args \\ [], opts \\ %{}) do
     opts = Map.merge(opts, @default_opts)
-
-    stream
-    |> Stream.transform(
-      fn ->
-        {:ok, server} = ProcServer.start_link(cmd, args, opts)
-        server
-      end,
-      fn data, server ->
-        with :ok <- ProcServer.write(server, data),
-             {:ok, data} <- ProcServer.read(server) do
-          {[data], server}
-        else
-          :eof ->
-            case ProcServer.status(server) do
-              {:done, 0} -> {:halt, server}
-              {:done, status} -> raise "command exited with status: #{status}"
-            end
-
-          error ->
-            Logger.warn(error)
-            raise error
-        end
-      end,
-      fn server ->
-        # always close stdin before stoping to give the command chance to exit properly
-        ProcServer.close_input(server)
-        ProcServer.stop(server)
-      end
-    )
+    ExCmd.Stream.__build__(cmd, args, opts)
   end
 end

--- a/lib/ex_cmd/fifo.ex
+++ b/lib/ex_cmd/fifo.ex
@@ -24,7 +24,8 @@ defmodule ExCmd.FIFO do
   end
 
   def handle_cast({:write, data, dst}, %{mode: :write} = state) do
-    data = [<<byte_size(data)::16>>, data]
+    size = IO.iodata_length(data)
+    data = [<<size::16>>, data]
 
     case :file.write(state.fifo, data) do
       :ok ->

--- a/lib/ex_cmd/proc_server.ex
+++ b/lib/ex_cmd/proc_server.ex
@@ -30,14 +30,14 @@ defmodule ExCmd.ProcServer do
 
   def open_output(server), do: GenServer.call(server, {:open_fifo, :output})
 
-  def read(server) do
-    GenServer.call(server, :read)
+  def read(server, timeout \\ :infinity) do
+    GenServer.call(server, :read, timeout)
   catch
     :exit, {:normal, _} -> :closed
   end
 
-  def write(server, data) do
-    GenServer.call(server, {:write, data})
+  def write(server, data, timeout \\ :infinity) do
+    GenServer.call(server, {:write, data}, timeout)
   catch
     :exit, {:normal, _} -> :closed
   end

--- a/lib/ex_cmd/proc_server.ex
+++ b/lib/ex_cmd/proc_server.ex
@@ -26,6 +26,12 @@ defmodule ExCmd.ProcServer do
     })
   end
 
+  def run(server), do: GenServer.call(server, :run)
+
+  def open_input(server), do: GenServer.call(server, {:open_fifo, :input})
+
+  def open_output(server), do: GenServer.call(server, {:open_fifo, :output})
+
   def read(server), do: GenServer.call(server, :read)
 
   def write(server, data), do: GenServer.call(server, {:write, data})
@@ -36,6 +42,8 @@ defmodule ExCmd.ProcServer do
 
   def status(server), do: GenServer.call(server, :status)
 
+  def await_exit(server, timeout \\ :infinity), do: GenServer.call(server, {:await_exit, timeout})
+
   def port_info(server), do: GenServer.call(server, :port_info)
 
   def init(params) do
@@ -43,6 +51,8 @@ defmodule ExCmd.ProcServer do
   end
 
   def handle_continue(params, _) do
+    Process.flag(:trap_exit, true)
+
     Temp.track!()
     dir = Temp.mkdir!()
     input_fifo_path = Temp.path!(%{basedir: dir})
@@ -51,12 +61,46 @@ defmodule ExCmd.ProcServer do
     output_fifo_path = Temp.path!(%{basedir: dir})
     FIFO.create(output_fifo_path)
 
-    port = start_odu_port(params, input_fifo_path, output_fifo_path)
+    {:noreply,
+     %{
+       state: :init,
+       input_fifo_path: input_fifo_path,
+       output_fifo_path: output_fifo_path,
+       params: params
+     }}
+  end
 
-    {:ok, input_fifo} = GenServer.start_link(FIFO, %{path: input_fifo_path, mode: :write})
-    {:ok, output_fifo} = GenServer.start_link(FIFO, %{path: output_fifo_path, mode: :read})
+  def handle_call(:run, _, state) do
+    port = start_odu_port(state.params, state.input_fifo_path, state.output_fifo_path)
+    {:reply, :ok, Map.merge(state, %{port: port, state: :started})}
+  end
 
-    {:noreply, %{state: :started, port: port, input: input_fifo, output: output_fifo}}
+  def handle_call({:open_fifo, :input}, from, state) do
+    {:ok, input_fifo} = GenServer.start_link(FIFO, %{path: state.input_fifo_path, mode: :write})
+    FIFO.open(input_fifo, from)
+    {:noreply, Map.put(state, :input, input_fifo)}
+  end
+
+  def handle_call({:open_fifo, :output}, from, state) do
+    {:ok, output_fifo} = GenServer.start_link(FIFO, %{path: state.output_fifo_path, mode: :read})
+    FIFO.open(output_fifo, from)
+    {:noreply, Map.put(state, :output, output_fifo)}
+  end
+
+  def handle_call({:await_exit, _}, _, %{state: {:done, status}} = state) do
+    {:reply, {:ok, status}, state}
+  end
+
+  def handle_call({:await_exit, timeout}, from, state) do
+    state =
+      if timeout != :infinity do
+        timeout_ref = Process.send_after(self(), {:await_timeout, from}, timeout)
+        Map.put(state, :timeout_ref, timeout_ref)
+      else
+        state
+      end
+
+    {:noreply, Map.put(state, :waiting_process, from)}
   end
 
   def handle_call(:status, _, %{state: proc_state} = state) do
@@ -67,8 +111,12 @@ defmodule ExCmd.ProcServer do
     {:reply, Port.info(state.port), state}
   end
 
-  def handle_call({:write, _}, _, %{state: {:done, status}} = state) do
-    {:reply, {:command_exit, status}, state}
+  def handle_call({:write, _}, _, %{input: :closed} = state) do
+    {:reply, :closed, state}
+  end
+
+  def handle_call({:write, _}, _, %{state: {:done, _}} = state) do
+    {:reply, :closed, state}
   end
 
   def handle_call({:write, data}, from, state) do
@@ -81,14 +129,41 @@ defmodule ExCmd.ProcServer do
     {:noreply, state}
   end
 
-  def handle_call(:close_input, from, state) do
-    FIFO.close(state.input, from)
+  def handle_call(:close_input, _, %{input: :closed} = state) do
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:close_input, _, state) do
+    Process.exit(state.input, :kill)
+    {:reply, :ok, %{state | input: :closed}}
+  end
+
+  # ignore exit signals
+  def handle_info({:EXIT, _, _}, state) do
     {:noreply, state}
   end
 
   def handle_info({port, {:exit_status, status}}, %{port: port} = state) do
     Logger.info("command exited with status: #{status}")
+
+    {waiting_process, state} = Map.pop(state, :waiting_process)
+
+    if waiting_process do
+      GenServer.reply(waiting_process, {:ok, status})
+    end
+
+    {await_timeout, state} = Map.pop(state, :await_timeout)
+
+    if await_timeout do
+      :timer.cancel(await_timeout)
+    end
+
     {:noreply, %{state | state: {:done, status}}}
+  end
+
+  def handle_info({:await_timeout, pid}, state) do
+    GenServer.reply(pid, :timeout)
+    {:noreply, Map.drop(state, [:waiting_process, :timeout_ref])}
   end
 
   defp start_odu_port(params, input_fifo_path, output_fifo_path) do

--- a/lib/ex_cmd/proc_server.ex
+++ b/lib/ex_cmd/proc_server.ex
@@ -30,9 +30,17 @@ defmodule ExCmd.ProcServer do
 
   def open_output(server), do: GenServer.call(server, {:open_fifo, :output})
 
-  def read(server), do: GenServer.call(server, :read)
+  def read(server) do
+    GenServer.call(server, :read)
+  catch
+    :exit, {:normal, _} -> :closed
+  end
 
-  def write(server, data), do: GenServer.call(server, {:write, data})
+  def write(server, data) do
+    GenServer.call(server, {:write, data})
+  catch
+    :exit, {:normal, _} -> :closed
+  end
 
   def close_input(server), do: GenServer.call(server, :close_input)
 

--- a/lib/ex_cmd/proc_server.ex
+++ b/lib/ex_cmd/proc_server.ex
@@ -70,6 +70,7 @@ defmodule ExCmd.ProcServer do
      }}
   end
 
+  # TODO: re-check state machine and raise proper errors for invalid state transitions
   def handle_call(:run, _, state) do
     port = start_odu_port(state.params, state.input_fifo_path, state.output_fifo_path)
     {:reply, :ok, Map.merge(state, %{port: port, state: :started})}

--- a/lib/ex_cmd/stream.ex
+++ b/lib/ex_cmd/stream.ex
@@ -1,0 +1,89 @@
+defmodule ExCmd.Stream do
+  alias ExCmd.ProcServer
+  defstruct [:proc_server, :stream_opts]
+
+  @default_stream_opts %{exit_timeout: :infinity}
+
+  def __build__(cmd, args, opts) do
+    {stream_opts, proc_opts} = Map.split(opts, [:exit_timeout])
+    stream_opts = Map.merge(@default_stream_opts, stream_opts)
+
+    {:ok, proc} = ProcServer.start_link(cmd, args, proc_opts)
+    %ExCmd.Stream{proc_server: proc, stream_opts: stream_opts}
+  end
+
+  defimpl Collectable do
+    def into(%{proc_server: proc} = stream) do
+      :ok = ProcServer.open_input(proc)
+
+      collector_fun = fn
+        :ok, {:cont, x} ->
+          :ok = ProcServer.write(proc, x)
+
+        :ok, :done ->
+          :ok = ProcServer.close_input(proc)
+          stream
+
+        :ok, :halt ->
+          :ok = ProcServer.close_input(proc)
+      end
+
+      {:ok, collector_fun}
+    end
+  end
+
+  defimpl Enumerable do
+    def reduce(%{proc_server: proc, stream_opts: stream_opts}, acc, fun) do
+      start_fun = fn ->
+        :ok = ProcServer.run(proc)
+        :ok = ProcServer.open_output(proc)
+      end
+
+      next_fun = fn :ok ->
+        case ProcServer.read(proc) do
+          {:ok, x} ->
+            {[x], :ok}
+
+          :eof ->
+            {:halt, :normal}
+
+          error ->
+            raise error
+        end
+      end
+
+      after_fun = fn exit_type ->
+        try do
+          # always close stdin before stoping to give the command chance to exit properly
+          ProcServer.close_input(proc)
+
+          result = ProcServer.await_exit(proc, stream_opts.exit_timeout)
+
+          if exit_type == :normal_exit do
+            case result do
+              {:ok, 0} -> :ok
+              {:ok, status} -> raise "command exited with status: #{status}"
+              :timeout -> raise "command fail to exit within timeout: #{stream_opts.exit_timeout}"
+            end
+          end
+        after
+          ProcServer.stop(proc)
+        end
+      end
+
+      Stream.resource(start_fun, next_fun, after_fun).(acc, fun)
+    end
+
+    def count(_stream) do
+      {:error, __MODULE__}
+    end
+
+    def member?(_stream, _term) do
+      {:error, __MODULE__}
+    end
+
+    def slice(_stream) do
+      {:error, __MODULE__}
+    end
+  end
+end

--- a/test/ex_cmd/proc_server_test.exs
+++ b/test/ex_cmd/proc_server_test.exs
@@ -4,6 +4,9 @@ defmodule ExCmd.ProcServerTest do
 
   test "read" do
     {:ok, s} = ProcServer.start_link("echo", ["test"])
+    :ok = ProcServer.run(s)
+    :ok = ProcServer.open_input(s)
+    :ok = ProcServer.open_output(s)
     assert {:ok, "test\n"} == ProcServer.read(s)
     assert :eof == ProcServer.read(s)
     assert :ok == ProcServer.close_input(s)
@@ -14,6 +17,9 @@ defmodule ExCmd.ProcServerTest do
 
   test "write" do
     {:ok, s} = ProcServer.start_link("cat", [])
+    :ok = ProcServer.run(s)
+    :ok = ProcServer.open_input(s)
+    :ok = ProcServer.open_output(s)
     assert :ok == ProcServer.write(s, "hello")
     assert {:ok, "hello"} == ProcServer.read(s)
     assert :ok == ProcServer.write(s, "world")
@@ -33,6 +39,9 @@ defmodule ExCmd.ProcServerTest do
     # collect events in order and assert that we can still read from
     # stdout even after closing stdin
     {:ok, s} = ProcServer.start_link("base64", [])
+    :ok = ProcServer.run(s)
+    :ok = ProcServer.open_input(s)
+    :ok = ProcServer.open_output(s)
 
     # parallel reader should be blocked till we close stdin
     start_parallel_reader(s, logger)
@@ -60,6 +69,9 @@ defmodule ExCmd.ProcServerTest do
 
   test "external command kill" do
     {:ok, s} = ProcServer.start_link("cat", [])
+    :ok = ProcServer.run(s)
+    :ok = ProcServer.open_input(s)
+    :ok = ProcServer.open_output(s)
     os_pid = ProcServer.port_info(s)[:os_pid]
     assert os_process_alive?(os_pid)
 
@@ -74,6 +86,10 @@ defmodule ExCmd.ProcServerTest do
   test "external command forceful kill" do
     # cat command hangs waiting for EOF
     {:ok, s} = ProcServer.start_link("cat", [])
+    :ok = ProcServer.run(s)
+    :ok = ProcServer.open_input(s)
+    :ok = ProcServer.open_output(s)
+
     os_pid = ProcServer.port_info(s)[:os_pid]
     assert os_process_alive?(os_pid)
 
@@ -88,6 +104,9 @@ defmodule ExCmd.ProcServerTest do
 
   test "exit status" do
     {:ok, s} = ProcServer.start_link("cat", ["some_invalid_file_name"])
+    :ok = ProcServer.run(s)
+    :ok = ProcServer.open_input(s)
+    :ok = ProcServer.open_output(s)
     :timer.sleep(500)
     assert {:done, 1} == ProcServer.status(s)
   end
@@ -107,7 +126,7 @@ defmodule ExCmd.ProcServerTest do
     end
   end
 
-  def start_events_collector() do
+  def start_events_collector do
     {:ok, ordered_events} = Agent.start(fn -> [] end)
     ordered_events
   end

--- a/test/ex_cmd_test.exs
+++ b/test/ex_cmd_test.exs
@@ -4,9 +4,15 @@ defmodule ExCmdTest do
   test "stream" do
     str = "hello"
 
-    output =
+    proc_stream = ExCmd.stream!("cat")
+
+    Task.async(fn ->
       Stream.map(1..1000, fn _ -> str end)
-      |> ExCmd.stream("cat")
+      |> Enum.into(proc_stream)
+    end)
+
+    output =
+      proc_stream
       |> Enum.into("")
 
     assert IO.iodata_length(output) == 1000 * String.length(str)


### PR DESCRIPTION
These interface handles process management and simplifies the interface 

```elixir
proc_stream = ExCmd.stream!("cat")

Task.async(fn ->
    Stream.map(1..1000, fn _ -> "hello" end)
    |> Enum.into(proc_stream)
end)

output = Enum.into(proc_stream, "")
```