### PR TITLE
add process opts in `stream!/2`'s type spec

### DIFF
--- a/lib/ex_cmd.ex
+++ b/lib/ex_cmd.ex
@@ -51,7 +51,10 @@ defmodule ExCmd do
   @spec stream!(nonempty_list(String.t()),
           input: Enum.t() | collectable_func(),
           exit_timeout: timeout(),
-          chunk_size: pos_integer() | nil
+          chunk_size: pos_integer() | nil,
+          cd: String.t(),
+          env: [{String.t(), String.t()}],
+          log: boolean()
         ) :: ExCmd.Stream.t()
   def stream!(cmd_with_args, opts \\ []) do
     ExCmd.Stream.__build__(cmd_with_args, opts)


### PR DESCRIPTION
`stream!/2` call `ExCmd.Stream.__build__/2` and `__build__` accept both stream and process opt, add [process opts's type spec](https://github.com/akash-akya/ex_cmd/blob/0f4cefe0d75e87b2ec2f17807c18e88c5a43e12b/lib/ex_cmd/process.ex#L24-L28) to stream!'s to prevent Dialyzer's warning