### PR TITLE
Fix :input function arity error when using Stream.resource/3

### DIFF
--- a/lib/ex_cmd/stream.ex
+++ b/lib/ex_cmd/stream.ex
@@ -51,14 +51,14 @@ defmodule ExCmd.Stream do
       is_nil(input) ->
         :ok
 
-      !is_function(input) && Enumerable.impl_for(input) ->
-        spawn_link(fn ->
-          Enum.into(input, sink)
-        end)
-
       is_function(input, 1) ->
         spawn_link(fn ->
           input.(sink)
+        end)
+
+      Enumerable.impl_for(input) ->
+        spawn_link(fn ->
+          Enum.into(input, sink)
         end)
 
       true ->

--- a/test/ex_cmd/stream_test.exs
+++ b/test/ex_cmd/stream_test.exs
@@ -1,0 +1,30 @@
+defmodule ExCmd.StreamTest do
+  use ExUnit.Case, async: true
+
+  test "simple stream input" do
+    stream =
+      1..10
+      |> Stream.map(&to_string/1)
+      |> Stream.take(5)
+
+    assert ["12345"] =
+             ExCmd.stream!(~w(cat), input: stream)
+             |> Enum.to_list()
+  end
+
+  test "resource stream input" do
+    stream =
+      Stream.resource(
+        fn -> 0 end,
+        fn last ->
+          n = last + 1
+          if n > 5, do: {:halt, nil}, else: {[to_string(n)], n}
+        end,
+        fn _ -> nil end
+      )
+
+    assert ["12345"] =
+             ExCmd.stream!(~w(cat), input: stream)
+             |> Enum.to_list()
+  end
+end

--- a/test/ex_cmd/stream_test.exs
+++ b/test/ex_cmd/stream_test.exs
@@ -7,9 +7,9 @@ defmodule ExCmd.StreamTest do
       |> Stream.map(&to_string/1)
       |> Stream.take(5)
 
-    assert ["12345"] =
+    assert "12345" =
              ExCmd.stream!(~w(cat), input: stream)
-             |> Enum.to_list()
+             |> Enum.into("")
   end
 
   test "resource stream input" do
@@ -23,8 +23,8 @@ defmodule ExCmd.StreamTest do
         fn _ -> nil end
       )
 
-    assert ["12345"] =
+    assert "12345" =
              ExCmd.stream!(~w(cat), input: stream)
-             |> Enum.to_list()
+             |> Enum.into("")
   end
 end


### PR DESCRIPTION
Currently, passing a `Stream.resource/3` (or other simple stream items) results in the following error (#18):

```elixir
** (ArgumentError) :input must be either Enumerable or a function with arity 1
    (ex_cmd 0.8.0) lib/ex_cmd/stream.ex:65: ExCmd.Stream.start_input_streamer/2
    (ex_cmd 0.8.0) lib/ex_cmd/stream.ex:44: ExCmd.Stream.__build__/2
    iex:4: (file)
```

It looks like the functions tried in `ExCmd.Stream.start_input_streamer/2` are failing because of some logic and the order they're defined.  This patch fixes the logic and adds a test to catch the case with certain types of Streams.