### PR TITLE
Fix streaming input memory usage

### DIFF
--- a/lib/ex_cmd/stream.ex
+++ b/lib/ex_cmd/stream.ex
@@ -51,14 +51,14 @@ defmodule ExCmd.Stream do
       is_nil(input) ->
         :ok
 
-      !is_function(input) && Enumerable.impl_for(input) ->
-        spawn_link(fn ->
-          Enum.into(input, sink)
-        end)
-
       is_function(input, 1) ->
         spawn_link(fn ->
           input.(sink)
+        end)
+
+      Enumerable.impl_for(input) ->
+        spawn_link(fn ->
+          Enum.into(input, sink)
         end)
 
       true ->

--- a/lib/ex_cmd/stream.ex
+++ b/lib/ex_cmd/stream.ex
@@ -58,7 +58,9 @@ defmodule ExCmd.Stream do
 
       Enumerable.impl_for(input) ->
         spawn_link(fn ->
-          Enum.into(input, sink)
+          input
+          |> Stream.into(sink)
+          |> Stream.run()
         end)
 
       true ->

--- a/test/ex_cmd/stream_test.exs
+++ b/test/ex_cmd/stream_test.exs
@@ -1,0 +1,30 @@
+defmodule ExCmd.StreamTest do
+  use ExUnit.Case, async: true
+
+  test "simple stream input" do
+    stream =
+      1..10
+      |> Stream.map(&to_string/1)
+      |> Stream.take(5)
+
+    assert ["12345"] =
+             ExCmd.stream!(~w(cat), input: stream)
+             |> Enum.to_list()
+  end
+
+  test "resource stream input" do
+    stream =
+      Stream.resource(
+        fn -> 0 end,
+        fn last ->
+          n = last + 1
+          if n > 5, do: {:halt, nil}, else: {[to_string(n)], n}
+        end,
+        fn _ -> nil end
+      )
+
+    assert ["12345"] =
+             ExCmd.stream!(~w(cat), input: stream)
+             |> Enum.to_list()
+  end
+end


### PR DESCRIPTION
Per #21 - the input stream option currently uses `Enum.into/2`, which eager-loads the stream before sending it to the process.  Instead, propose to use `Stream.into/2` so that the stream is able to pass chunks to the process as they're needed.

Note, this commit includes PR #20 