### PR TITLE
Fix exit tuple description in the docs

### DIFF
--- a/lib/ex_cmd.ex
+++ b/lib/ex_cmd.ex
@@ -296,7 +296,8 @@ defmodule ExCmd do
   element of the stream.
 
   The last element will be of the form `{:exit, term()}`. `term` will be a
-  positive integer in case of normal exit and `:epipe` in case of epipe error
+  two-element tuple with `:status` and a positive integer in case of normal exit
+  (e.g. `{:status, 0}` or `{:status, 2}`), and `:epipe` in case of epipe error.
 
   See `ExCmd.stream!/2` documentation for details about the options and
   examples.


### PR DESCRIPTION
If I'm reading it right, the documentation says you will get a tuple like `{:exit, 0}`, when it will actually be `{:exit, {:status, 0}}`.